### PR TITLE
My paper was published in UAI 2019, not 2020

### DIFF
--- a/_posts/2020-08-06-ji20a.md
+++ b/_posts/2020-08-06-ji20a.md
@@ -41,7 +41,7 @@ author:
   family: Xiong
 - given: Erik B.
   family: Sudderth
-date: 2020-08-06
+date: 2019
 address: 
 publisher: PMLR
 container-title: Proceedings of The 35th Uncertainty in Artificial Intelligence Conference


### PR DESCRIPTION
My paper was published in UAI 2019, not 2020